### PR TITLE
Collect monetateId as trait from cookie, if available

### DIFF
--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -46,6 +46,14 @@ Monetate.prototype.initialize = function() {
     };
   }
   window.monetateQ = window.monetateQ || [];
+  
+  // Get monetateId from cookie, if available.
+  var monetateIdCookie = document.cookie.match('(^|;) ?mt.v=([^;]*)(;|$)');
+  var monetateId = monetateIdCookie ? monetateIdCookie[2] : null;
+  if (monetateId) {
+      this.options.context.traits.monetateId = monetateId; 
+  }
+  
   this.ready();
 };
 


### PR DESCRIPTION
**What does this PR do?**

Monetate sets its own ID to track users during a session.  That ID is set as a cookie, `mt.v`.  This PR collects that ID as a trait.

The "Monetate Engine API" Destination Component can then associate the event with the proper user session.  This allows us to better personalize the user's experience (e.g. by targeting behavior that occurred earlier in the session).

**Are there breaking changes in this PR?**

No.

**Any background context you want to provide?**

Monetate identifies visitors and tracks sessions via the Monetate ID. This ID is generated on the first request to Monetate (if it is not provided as part of the request) and identifies a unique device/browser. In JavaScript tag implementations, the Monetate tag sets the  `mt.v` cookie, which persists this ID for further calls to Monetate.

The Monetate ID looks like this: `5.1879957417.1544197401555`.

It is important that the Monetate ID is used to identify the visitor in all subsequent requests during the session.

This PR has been created to support the in-development "Monetate Engine API" Destination Component, which will receive `track` and `identify` events.  In the case of `track` events in particular, we need to pass the `monetateId` so we can determine the visitor session to which the event should be attributed.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

Not applicable.

**Does this require a new integration setting? If so, please explain how the new setting works**

No.

**Links to helpful docs and other external resources**

Our developer documentation is available only to logged-in Monetate users.  The relevant portion of the following document has been provided in the "background context" section:

https://knowledge.monetate.com/hc/en-us/articles/360020800172-Calling-The-Engine-API